### PR TITLE
Copy 32bit ARM Libs For 64bit Devices

### DIFF
--- a/chromium/Android.mk
+++ b/chromium/Android.mk
@@ -33,6 +33,12 @@ ifeq ($(TARGET_IS_64_BIT),true)
 TARGET_ARCH_ABI := arm64-v8a
 TARGET_LIB_DIR := lib64
 TARGET_LIB_ARM_DIR := arm64
+
+$(shell mkdir -p $(TARGET_OUT)/lib)
+$(shell cp $(LOCAL_PATH)/prebuilt/armeabi-v7a/libwebviewchromium.so $(TARGET_OUT)/lib/libwebviewchromium.so)
+$(shell mkdir -p $(TARGET_OUT_APPS)/webview/lib/arm)
+$(shell ln -sf ../../../../lib/libwebviewchromium.so $(TARGET_OUT_APPS)/webview/lib/arm/libwebviewchromium.so)
+
 else
 TARGET_ARCH_ABI := armeabi-v7a
 TARGET_LIB_DIR := lib


### PR DESCRIPTION
64bit requires 32bit ARM Libs for Play Services to work.

Change-Id: I7e43b1f92d31a0b712d2b5c8a2dc57076f182068
Signed-off-by: Men_in_black007 sanyam.53jain@gmail.com
